### PR TITLE
Add Mem0 memory tools

### DIFF
--- a/packages/types/src/tool.ts
+++ b/packages/types/src/tool.ts
@@ -31,10 +31,12 @@ export const toolNames = [
 	"attempt_completion",
 	"switch_mode",
 	"new_task",
-        "fetch_instructions",
-        "codebase_search",
-        "reference_search",
-        "read_reference_file",
+	"fetch_instructions",
+	"codebase_search",
+	"reference_search",
+	"read_reference_file",
+	"add_memory",
+	"search_memories",
 ] as const
 
 export const toolNamesSchema = z.enum(toolNames)

--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -33,6 +33,8 @@ import { Task } from "../task/Task"
 import { codebaseSearchTool } from "../tools/codebaseSearchTool"
 import { referenceSearchTool } from "../tools/referenceSearchTool"
 import { readReferenceFileTool } from "../tools/readReferenceFileTool"
+import { addMemoryTool } from "../tools/addMemoryTool"
+import { searchMemoriesTool } from "../tools/searchMemoriesTool"
 import { experiments, EXPERIMENT_IDS } from "../../shared/experiments"
 import { applyDiffToolLegacy } from "../tools/applyDiffTool"
 
@@ -211,6 +213,10 @@ export async function presentAssistantMessage(cline: Task) {
 						return `[${block.name} for '${block.params.query}']`
 					case "read_reference_file":
 						return `[${block.name} for '${block.params.path}']`
+					case "add_memory":
+						return `[${block.name}]`
+					case "search_memories":
+						return `[${block.name} for '${block.params.query}']`
 					case "new_task": {
 						const mode = block.params.mode ?? defaultModeSlug
 						const message = block.params.message ?? "(no message)"
@@ -484,6 +490,12 @@ export async function presentAssistantMessage(cline: Task) {
 						pushToolResult,
 						removeClosingTag,
 					)
+					break
+				case "add_memory":
+					await addMemoryTool(cline, block, askApproval, handleError, pushToolResult, removeClosingTag)
+					break
+				case "search_memories":
+					await searchMemoriesTool(cline, block, askApproval, handleError, pushToolResult, removeClosingTag)
 					break
 				case "search_files":
 					await searchFilesTool(cline, block, askApproval, handleError, pushToolResult, removeClosingTag)

--- a/src/core/prompts/tools/add-memory.ts
+++ b/src/core/prompts/tools/add-memory.ts
@@ -1,0 +1,6 @@
+export function getAddMemoryDescription(): string {
+	return `## add_memory
+Description: Store a text snippet in persistent memory for later retrieval.
+Parameters:
+- memory: (required) The text to store.`
+}

--- a/src/core/prompts/tools/index.ts
+++ b/src/core/prompts/tools/index.ts
@@ -24,6 +24,8 @@ import { getNewTaskDescription } from "./new-task"
 import { getCodebaseSearchDescription } from "./codebase-search"
 import { getReferenceSearchDescription } from "./reference-search"
 import { getReadReferenceFileDescription } from "./read-reference-file"
+import { getAddMemoryDescription } from "./add-memory"
+import { getSearchMemoriesDescription } from "./search-memories"
 import { CodeIndexManager } from "../../../services/code-index/manager"
 
 // Map of tool names to their description functions
@@ -47,6 +49,8 @@ const toolDescriptionMap: Record<string, (args: ToolArgs) => string | undefined>
 	new_task: (args) => getNewTaskDescription(args),
 	insert_content: (args) => getInsertContentDescription(args),
 	search_and_replace: (args) => getSearchAndReplaceDescription(args),
+	add_memory: () => getAddMemoryDescription(),
+	search_memories: () => getSearchMemoriesDescription(),
 	apply_diff: (args) =>
 		args.diffStrategy ? args.diffStrategy.getToolDescription({ cwd: args.cwd, toolOptions: args.toolOptions }) : "",
 }
@@ -147,4 +151,6 @@ export {
 	getCodebaseSearchDescription,
 	getReferenceSearchDescription,
 	getReadReferenceFileDescription,
+	getAddMemoryDescription,
+	getSearchMemoriesDescription,
 }

--- a/src/core/prompts/tools/search-memories.ts
+++ b/src/core/prompts/tools/search-memories.ts
@@ -1,0 +1,6 @@
+export function getSearchMemoriesDescription(): string {
+	return `## search_memories
+Description: Search previously stored memories.
+Parameters:
+- query: (required) Text to search for.`
+}

--- a/src/core/tools/addMemoryTool.ts
+++ b/src/core/tools/addMemoryTool.ts
@@ -1,0 +1,52 @@
+import { Task } from "../task/Task"
+import { store_memory } from "../../services/mem0"
+import { formatResponse } from "../prompts/responses"
+import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../shared/tools"
+
+export async function addMemoryTool(
+	cline: Task,
+	block: ToolUse,
+	askApproval: AskApproval,
+	handleError: HandleError,
+	pushToolResult: PushToolResult,
+	removeClosingTag: RemoveClosingTag,
+) {
+	const memory: string | undefined = block.params.memory
+	const toolName = "add_memory"
+	try {
+		if (block.partial) {
+			await cline.ask("tool", removeClosingTag("memory", memory), block.partial).catch(() => {})
+			return
+		} else {
+			if (!memory) {
+				cline.consecutiveMistakeCount++
+				cline.recordToolError(toolName)
+				pushToolResult(await cline.sayAndCreateMissingParamError(toolName, "memory"))
+				return
+			}
+
+			const didApprove = await askApproval("tool", removeClosingTag("memory", memory))
+			if (!didApprove) {
+				pushToolResult(formatResponse.toolDenied())
+				return
+			}
+
+			const state = await cline.providerRef.deref()?.getState()
+			if (!state?.mem0Enabled || !state.mem0ApiServerUrl) {
+				pushToolResult(formatResponse.toolError("Mem0 is not enabled"))
+				return
+			}
+			cline.consecutiveMistakeCount = 0
+			await store_memory(
+				[{ role: "assistant", content: [{ type: "text", text: memory }] }],
+				state.machineId ?? "",
+				cline.taskId,
+			)
+			pushToolResult("memory stored")
+			return
+		}
+	} catch (error) {
+		await handleError("adding memory", error as Error)
+		return
+	}
+}

--- a/src/core/tools/searchMemoriesTool.ts
+++ b/src/core/tools/searchMemoriesTool.ts
@@ -1,0 +1,53 @@
+import { Task } from "../task/Task"
+import { search_memories } from "../../services/mem0"
+import { formatResponse } from "../prompts/responses"
+import { ToolUse, AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "../../shared/tools"
+
+export async function searchMemoriesTool(
+	cline: Task,
+	block: ToolUse,
+	askApproval: AskApproval,
+	handleError: HandleError,
+	pushToolResult: PushToolResult,
+	removeClosingTag: RemoveClosingTag,
+) {
+	const query: string | undefined = block.params.query
+	const toolName = "search_memories"
+	try {
+		if (block.partial) {
+			await cline.ask("tool", removeClosingTag("query", query), block.partial).catch(() => {})
+			return
+		} else {
+			if (!query) {
+				cline.consecutiveMistakeCount++
+				cline.recordToolError(toolName)
+				pushToolResult(await cline.sayAndCreateMissingParamError(toolName, "query"))
+				return
+			}
+
+			const didApprove = await askApproval("tool", removeClosingTag("query", query))
+			if (!didApprove) {
+				pushToolResult(formatResponse.toolDenied())
+				return
+			}
+
+			const state = await cline.providerRef.deref()?.getState()
+			if (!state?.mem0Enabled || !state.mem0ApiServerUrl) {
+				pushToolResult(formatResponse.toolError("Mem0 is not enabled"))
+				return
+			}
+			cline.consecutiveMistakeCount = 0
+			const memories = await search_memories(query, state.machineId ?? "", cline.taskId)
+			if (!memories || memories.length === 0) {
+				pushToolResult("(no results)")
+			} else {
+				const out = memories.map((m: any) => m.text || m.memory).join("\n")
+				pushToolResult(out)
+			}
+			return
+		}
+	} catch (error) {
+		await handleError("searching memories", error as Error)
+		return
+	}
+}

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -64,6 +64,7 @@ export const toolParamNames = [
 	"end_line",
 	"query",
 	"args",
+	"memory",
 ] as const
 
 export type ToolParamName = (typeof toolParamNames)[number]
@@ -167,6 +168,16 @@ export interface NewTaskToolUse extends ToolUse {
 	params: Partial<Pick<Record<ToolParamName, string>, "mode" | "message">>
 }
 
+export interface AddMemoryToolUse extends ToolUse {
+	name: "add_memory"
+	params: Partial<Pick<Record<ToolParamName, string>, "memory">>
+}
+
+export interface SearchMemoriesToolUse extends ToolUse {
+	name: "search_memories"
+	params: Partial<Pick<Record<ToolParamName, string>, "query">>
+}
+
 export interface SearchAndReplaceToolUse extends ToolUse {
 	name: "search_and_replace"
 	params: Required<Pick<Record<ToolParamName, string>, "path" | "search" | "replace">> &
@@ -200,6 +211,8 @@ export const TOOL_DISPLAY_NAMES: Record<ToolName, string> = {
 	codebase_search: "codebase search",
 	reference_search: "reference search",
 	read_reference_file: "read reference",
+	add_memory: "add memory",
+	search_memories: "search memories",
 } as const
 
 // Define available tool groups.
@@ -240,6 +253,8 @@ export const ALWAYS_AVAILABLE_TOOLS: ToolName[] = [
 	"attempt_completion",
 	"switch_mode",
 	"new_task",
+	"add_memory",
+	"search_memories",
 ] as const
 
 export type DiffResult =


### PR DESCRIPTION
## Summary
- allow `add_memory` and `search_memories` tools
- expose the new tools in prompts and assistant message handling
- extend tool types with `memory` param and new tool uses
- document new tools for the model

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm test` *(fails: connect ENETUNREACH 104.16.3.35:443)*

------
https://chatgpt.com/codex/tasks/task_e_68699a09d804832f871c69a2834ae549