### PR TITLE
Enhance mem0 integration for tools

### DIFF
--- a/src/core/tools/listCodeDefinitionNamesTool.ts
+++ b/src/core/tools/listCodeDefinitionNamesTool.ts
@@ -8,6 +8,7 @@ import { getReadablePath } from "../../utils/path"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
 import { parseSourceCodeForDefinitionsTopLevel, parseSourceCodeDefinitionsForFile } from "../../services/tree-sitter"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
+import { store_memory } from "../../services/mem0"
 
 export async function listCodeDefinitionNamesTool(
 	cline: Task,
@@ -73,10 +74,63 @@ export async function listCodeDefinitionNamesTool(
 			}
 
 			pushToolResult(result)
+
+			const state = await cline.providerRef.deref()?.getState()
+			if (state?.mem0Enabled && state.mem0ApiServerUrl) {
+				await store_memory(
+					[
+						{
+							role: "system",
+							content: [
+								{
+									type: "text",
+									text: `[tool:list_code_definition_names] ${relPath}`,
+								},
+							],
+						},
+						{
+							role: "assistant",
+							content: [{ type: "text", text: result }],
+						},
+					],
+					state.machineId ?? "",
+					cline.taskId,
+					{ category: "list_code_definition_names", path: relPath, status: "success" },
+				)
+			}
 			return
 		}
 	} catch (error) {
 		await handleError("parsing source code definitions", error)
+
+		const state = await cline.providerRef.deref()?.getState()
+		if (state?.mem0Enabled && state.mem0ApiServerUrl) {
+			await store_memory(
+				[
+					{
+						role: "system",
+						content: [
+							{
+								type: "text",
+								text: `[tool:list_code_definition_names] ${relPath}`,
+							},
+						],
+					},
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "text",
+								text: `Error parsing definitions: ${error instanceof Error ? error.message : String(error)}`,
+							},
+						],
+					},
+				],
+				state.machineId ?? "",
+				cline.taskId,
+				{ category: "list_code_definition_names", path: relPath, status: "error" },
+			)
+		}
 		return
 	}
 }


### PR DESCRIPTION
## Summary
- import mem0 client in file and command tools
- store tool results in mem0 when enabled

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*
- `pnpm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686997451494832fa820a5a9e12f73a8