### PR TITLE
Fix types and update interfaces

### DIFF
--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -8,14 +8,8 @@ import {
 	providerSettingsSchema,
 } from "./provider-settings.js"
 import { historyItemSchema } from "./history.js"
-import {
-        codebaseIndexModelsSchema,
-        codebaseIndexConfigSchema,
-} from "./codebase-index.js"
-import {
-        referenceIndexModelsSchema,
-        referenceIndexConfigSchema,
-} from "./reference-index.js"
+import { codebaseIndexModelsSchema, codebaseIndexConfigSchema } from "./codebase-index.js"
+import { referenceIndexModelsSchema, referenceIndexConfigSchema } from "./reference-index.js"
 import { experimentsSchema } from "./experiment.js"
 import { telemetrySettingsSchema } from "./telemetry.js"
 import { modeConfigSchema } from "./mode.js"
@@ -63,12 +57,12 @@ export const globalSettingsSchema = z.object({
 	browserToolEnabled: z.boolean().optional(),
 	browserViewportSize: z.string().optional(),
 	screenshotQuality: z.number().optional(),
-        remoteBrowserEnabled: z.boolean().optional(),
-        remoteBrowserHost: z.string().optional(),
-        cachedChromeHostUrl: z.string().optional(),
+	remoteBrowserEnabled: z.boolean().optional(),
+	remoteBrowserHost: z.string().optional(),
+	cachedChromeHostUrl: z.string().optional(),
 
-        mem0Enabled: z.boolean().optional(),
-        mem0ApiServerUrl: z.string().optional(),
+	mem0Enabled: z.boolean().optional(),
+	mem0ApiServerUrl: z.string().optional(),
 
 	enableCheckpoints: z.boolean().optional(),
 
@@ -96,16 +90,18 @@ export const globalSettingsSchema = z.object({
 	rateLimitSeconds: z.number().optional(),
 	diffEnabled: z.boolean().optional(),
 	fuzzyMatchThreshold: z.number().optional(),
-        experiments: experimentsSchema.optional(),
+	experiments: experimentsSchema.optional(),
 
-        codebaseIndexModels: codebaseIndexModelsSchema.optional(),
-        codebaseIndexConfig: codebaseIndexConfigSchema.optional(),
-        referenceIndexModels: referenceIndexModelsSchema.optional(),
-        referenceIndexConfig: referenceIndexConfigSchema.optional(),
+	codebaseIndexModels: codebaseIndexModelsSchema.optional(),
+	codebaseIndexConfig: codebaseIndexConfigSchema.optional(),
+	referenceIndexModels: referenceIndexModelsSchema.optional(),
+	referenceIndexConfig: referenceIndexConfigSchema.optional(),
 
 	language: languagesSchema.optional(),
 
 	telemetrySetting: telemetrySettingsSchema.optional(),
+
+	machineId: z.string().optional(),
 
 	mcpEnabled: z.boolean().optional(),
 	enableMcpServerCreation: z.boolean().optional(),
@@ -158,10 +154,10 @@ export const SECRET_STATE_KEYS = [
 	"litellmApiKey",
 	"codeIndexOpenAiKey",
 	"codeIndexQdrantApiKey",
-        "codebaseIndexOpenAiCompatibleApiKey",
-        "codebaseIndexGeminiApiKey",
-        "referenceIndexOpenAiCompatibleApiKey",
-        "referenceIndexGeminiApiKey",
+	"codebaseIndexOpenAiCompatibleApiKey",
+	"codebaseIndexGeminiApiKey",
+	"referenceIndexOpenAiCompatibleApiKey",
+	"referenceIndexGeminiApiKey",
 ] as const satisfies readonly (keyof ProviderSettings)[]
 export type SecretState = Pick<ProviderSettings, (typeof SECRET_STATE_KEYS)[number]>
 
@@ -215,9 +211,9 @@ export const EVALS_SETTINGS: RooCodeSettings = {
 	browserToolEnabled: false,
 	browserViewportSize: "900x600",
 	screenshotQuality: 75,
-        remoteBrowserEnabled: false,
+	remoteBrowserEnabled: false,
 
-        mem0Enabled: false,
+	mem0Enabled: false,
 
 	ttsEnabled: false,
 	ttsSpeed: 1,

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -166,13 +166,13 @@ export class Task extends EventEmitter<ClineEvents> {
 	browserSession: BrowserSession
 
 	// Editing
-        diffViewProvider: DiffViewProvider
-        diffStrategy?: DiffStrategy
-        diffEnabled: boolean = false
-        fuzzyMatchThreshold: number
-        didEditFile: boolean = false
+	diffViewProvider: DiffViewProvider
+	diffStrategy?: DiffStrategy
+	diffEnabled: boolean = false
+	fuzzyMatchThreshold: number
+	didEditFile: boolean = false
 
-        initialTask?: string
+	initialTask?: string
 
 	// LLM Messages & Chat Messages
 	apiConversationHistory: ApiMessage[] = []
@@ -259,10 +259,10 @@ export class Task extends EventEmitter<ClineEvents> {
 		this.diffViewProvider = new DiffViewProvider(this.cwd)
 		this.enableCheckpoints = enableCheckpoints
 
-                this.rootTask = rootTask
-                this.parentTask = parentTask
-                this.taskNumber = taskNumber
-                this.initialTask = task ?? historyItem?.task
+		this.rootTask = rootTask
+		this.parentTask = parentTask
+		this.taskNumber = taskNumber
+		this.initialTask = task ?? historyItem?.task
 
 		if (historyItem) {
 			TelemetryService.instance.captureTaskRestarted(this.taskId)
@@ -1515,19 +1515,20 @@ export class Task extends EventEmitter<ClineEvents> {
 					content: [{ type: "text", text: assistantMessage }],
 				})
 
-                                TelemetryService.instance.captureConversationMessage(this.taskId, "assistant")
+				TelemetryService.instance.captureConversationMessage(this.taskId, "assistant")
 
-                                if (state?.mem0Enabled && state.mem0ApiServerUrl) {
-                                        await store_memory(
-                                                [
-                                                        { role: "user", content: finalUserContent },
-                                                        { role: "assistant", content: [{ type: "text", text: assistantMessage }] },
-                                                ],
-                                                state.machineId ?? "",
-                                                this.taskId,
-                                                { category: "task", status: "success" },
-                                        )
-                                }
+				const state = await this.providerRef.deref()?.getState()
+				if (state?.mem0Enabled && state.mem0ApiServerUrl) {
+					await store_memory(
+						[
+							{ role: "user", content: finalUserContent },
+							{ role: "assistant", content: [{ type: "text", text: assistantMessage }] },
+						],
+						state.machineId ?? "",
+						this.taskId,
+						{ category: "task", status: "success" },
+					)
+				}
 
 				// NOTE: This comment is here for future reference - this was a
 				// workaround for `userMessageContent` not getting set to true.
@@ -1732,7 +1733,9 @@ export class Task extends EventEmitter<ClineEvents> {
 
 			const contextWindow = modelInfo.contextWindow
 
-			const currentProfileId = state?.listApiConfigMeta.find((profile) => profile.name === state?.currentApiConfigName)?.id ?? "default";
+			const currentProfileId =
+				state?.listApiConfigMeta.find((profile) => profile.name === state?.currentApiConfigName)?.id ??
+				"default"
 
 			const truncateResult = await truncateConversationIfNeeded({
 				messages: this.apiConversationHistory,
@@ -1789,20 +1792,25 @@ export class Task extends EventEmitter<ClineEvents> {
 			}
 		}
 
-                const metadata: ApiHandlerCreateMessageMetadata = {
-                        mode: mode,
-                        taskId: this.taskId,
-                }
+		const metadata: ApiHandlerCreateMessageMetadata = {
+			mode: mode,
+			taskId: this.taskId,
+		}
 
-                if (state?.mem0Enabled && state.mem0ApiServerUrl && this.initialTask) {
-                        const memories = await search_memories(this.initialTask, state.machineId ?? "", this.taskId)
-                        if (memories && Array.isArray(memories) && memories.length > 0) {
-                                cleanConversationHistory.unshift({
-                                        role: "user",
-                                        content: [{ type: "text", text: `[memories]\n${memories.map((m: any) => m.text || m.memory).join("\n")}` }],
-                                })
-                        }
-                }
+		if (state?.mem0Enabled && state.mem0ApiServerUrl && this.initialTask) {
+			const memories = await search_memories(this.initialTask, state.machineId ?? "", this.taskId)
+			if (memories && Array.isArray(memories) && memories.length > 0) {
+				cleanConversationHistory.unshift({
+					role: "user",
+					content: [
+						{
+							type: "text",
+							text: `[memories]\n${memories.map((m: any) => m.text || m.memory).join("\n")}`,
+						},
+					],
+				})
+			}
+		}
 
 		const stream = this.api.createMessage(systemPrompt, cleanConversationHistory, metadata)
 		const iterator = stream[Symbol.asyncIterator]()

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -8,7 +8,7 @@ import delay from "delay"
 import axios from "axios"
 import pWaitFor from "p-wait-for"
 import * as vscode from "vscode"
-import { configureMem0 } from "../../services/mem0"
+import { configureMem0, store_memory } from "../../services/mem0"
 
 import {
 	type GlobalState,
@@ -468,7 +468,7 @@ export class ClineProvider
 			this.referenceIndexStatusSubscription = this.referenceIndexManager.onProgressUpdate(
 				(update: IndexProgressUpdate) => {
 					this.postMessageToWebview({
-						type: "referenceIndexingStatusUpdate",
+						type: "indexingStatusUpdate",
 						values: update,
 					})
 				},
@@ -819,32 +819,32 @@ export class ClineProvider
 	 * Handle switching to a new mode, including updating the associated API configuration
 	 * @param newMode The mode to switch to
 	 */
-        public async handleModeSwitch(newMode: Mode) {
-                const cline = this.getCurrentCline()
+	public async handleModeSwitch(newMode: Mode) {
+		const cline = this.getCurrentCline()
 
-                if (cline) {
-                        TelemetryService.instance.captureModeSwitch(cline.taskId, newMode)
-                        cline.emit("taskModeSwitched", cline.taskId, newMode)
-                        const state = await this.getState()
-                        if (state.mem0Enabled && state.mem0ApiServerUrl) {
-                                store_memory(
-                                        [
-                                                {
-                                                        role: "system",
-                                                        content: [
-                                                                {
-                                                                        type: "text",
-                                                                        text: `Mode switched to ${newMode}`,
-                                                                },
-                                                        ],
-                                                },
-                                        ],
-                                        state.machineId ?? "",
-                                        cline.taskId,
-                                        { category: "mode-switch", mode: newMode },
-                                )
-                        }
-                }
+		if (cline) {
+			TelemetryService.instance.captureModeSwitch(cline.taskId, newMode)
+			cline.emit("taskModeSwitched", cline.taskId, newMode)
+			const state = await this.getState()
+			if (state.mem0Enabled && state.mem0ApiServerUrl) {
+				store_memory(
+					[
+						{
+							role: "system",
+							content: [
+								{
+									type: "text",
+									text: `Mode switched to ${newMode}`,
+								},
+							],
+						},
+					],
+					state.machineId ?? "",
+					cline.taskId,
+					{ category: "mode-switch", mode: newMode },
+				)
+			}
+		}
 
 		await this.updateGlobalState("mode", newMode)
 
@@ -1399,12 +1399,12 @@ export class ClineProvider
 			taskHistory,
 			soundVolume,
 			browserViewportSize,
-                        screenshotQuality,
-                        remoteBrowserHost,
-                        remoteBrowserEnabled,
-                        mem0Enabled,
-                        mem0ApiServerUrl,
-                        cachedChromeHostUrl,
+			screenshotQuality,
+			remoteBrowserHost,
+			remoteBrowserEnabled,
+			mem0Enabled,
+			mem0ApiServerUrl,
+			cachedChromeHostUrl,
 			writeDelayMs,
 			terminalOutputLineLimit,
 			terminalShellIntegrationTimeout,
@@ -1497,12 +1497,12 @@ export class ClineProvider
 			allowedCommands: mergedAllowedCommands,
 			soundVolume: soundVolume ?? 0.5,
 			browserViewportSize: browserViewportSize ?? "900x600",
-                        screenshotQuality: screenshotQuality ?? 75,
-                        remoteBrowserHost,
-                        remoteBrowserEnabled: remoteBrowserEnabled ?? false,
-                        mem0Enabled: mem0Enabled ?? false,
-                        mem0ApiServerUrl,
-                        cachedChromeHostUrl: cachedChromeHostUrl,
+			screenshotQuality: screenshotQuality ?? 75,
+			remoteBrowserHost,
+			remoteBrowserEnabled: remoteBrowserEnabled ?? false,
+			mem0Enabled: mem0Enabled ?? false,
+			mem0ApiServerUrl,
+			cachedChromeHostUrl: cachedChromeHostUrl,
 			writeDelayMs: writeDelayMs ?? 1000,
 			terminalOutputLineLimit: terminalOutputLineLimit ?? 500,
 			terminalShellIntegrationTimeout: terminalShellIntegrationTimeout ?? Terminal.defaultShellIntegrationTimeout,
@@ -1574,17 +1574,17 @@ export class ClineProvider
 	 * https://www.eliostruyf.com/devhack-code-extension-storage-options/
 	 */
 
-        async getState() {
-                const stateValues = this.contextProxy.getValues()
+	async getState() {
+		const stateValues = this.contextProxy.getValues()
 
-                const mem0EnabledEnv = process.env.MEM0_ENABLED === "true"
-                const mem0UrlEnv = process.env.MEM0_API_SERVER_URL
+		const mem0EnabledEnv = process.env.MEM0_ENABLED === "true"
+		const mem0UrlEnv = process.env.MEM0_API_SERVER_URL
 
-                const mem0Enabled = stateValues.mem0Enabled ?? mem0EnabledEnv
-                const mem0ApiServerUrl = stateValues.mem0ApiServerUrl ?? mem0UrlEnv
+		const mem0Enabled = stateValues.mem0Enabled ?? mem0EnabledEnv
+		const mem0ApiServerUrl = stateValues.mem0ApiServerUrl ?? mem0UrlEnv
 
-                configureMem0({ enabled: mem0Enabled ?? false, baseUrl: mem0ApiServerUrl })
-                const customModes = await this.customModesManager.getCustomModes()
+		configureMem0({ enabled: mem0Enabled ?? false, baseUrl: mem0ApiServerUrl })
+		const customModes = await this.customModesManager.getCustomModes()
 
 		// Determine apiProvider with the same logic as before.
 		const apiProvider: ProviderName = stateValues.apiProvider ? stateValues.apiProvider : "anthropic"
@@ -1667,12 +1667,12 @@ export class ClineProvider
 			enableCheckpoints: stateValues.enableCheckpoints ?? true,
 			soundVolume: stateValues.soundVolume,
 			browserViewportSize: stateValues.browserViewportSize ?? "900x600",
-                        screenshotQuality: stateValues.screenshotQuality ?? 75,
-                        remoteBrowserHost: stateValues.remoteBrowserHost,
-                        remoteBrowserEnabled: stateValues.remoteBrowserEnabled ?? false,
-                        mem0Enabled: stateValues.mem0Enabled ?? false,
-                        mem0ApiServerUrl: stateValues.mem0ApiServerUrl,
-                        cachedChromeHostUrl: stateValues.cachedChromeHostUrl as string | undefined,
+			screenshotQuality: stateValues.screenshotQuality ?? 75,
+			remoteBrowserHost: stateValues.remoteBrowserHost,
+			remoteBrowserEnabled: stateValues.remoteBrowserEnabled ?? false,
+			mem0Enabled: stateValues.mem0Enabled ?? false,
+			mem0ApiServerUrl: stateValues.mem0ApiServerUrl,
+			cachedChromeHostUrl: stateValues.cachedChromeHostUrl as string | undefined,
 			fuzzyMatchThreshold: stateValues.fuzzyMatchThreshold ?? 1.0,
 			writeDelayMs: stateValues.writeDelayMs ?? 1000,
 			terminalOutputLineLimit: stateValues.terminalOutputLineLimit ?? 500,

--- a/src/integrations/jupyter/__tests__/execute-cell.test.ts
+++ b/src/integrations/jupyter/__tests__/execute-cell.test.ts
@@ -32,7 +32,7 @@ const mockNotebook = {
 describe("executeNotebookCell", () => {
 	beforeEach(() => {
 		// Provide mock implementations for vscode APIs
-		;(vscode.Uri.file as MockedFunction<typeof vscode.Uri.file>).mockImplementation((p: string) => ({
+		;(vscode.Uri.file as any).mockImplementation((p: string) => ({
 			fsPath: p,
 			path: p,
 		}))
@@ -41,16 +41,14 @@ describe("executeNotebookCell", () => {
 		).mockResolvedValue({
 			getText: () => JSON.stringify(mockNotebook),
 		} as any)
-		;(
-			vscode.NotebookCellOutputItem.text as MockedFunction<typeof vscode.NotebookCellOutputItem.text>
-		).mockImplementation((value: string, mime: string) => ({
+		;(vscode.NotebookCellOutputItem.text as any).mockImplementation((value: string, mime: string) => ({
 			data: Buffer.from(value),
 			mime,
 		}))
 
 		// Mock file system operations
-		;(fs.writeFile as MockedFunction<typeof fs.writeFile>).mockResolvedValue(undefined)
-		;(fs.unlink as MockedFunction<typeof fs.unlink>).mockResolvedValue(undefined)
+		;(fs.writeFile as any).mockResolvedValue(undefined)
+		;(fs.unlink as any).mockResolvedValue(undefined)
 	})
 
 	afterEach(() => {

--- a/src/integrations/jupyter/__tests__/run-notebook-cell.test.ts
+++ b/src/integrations/jupyter/__tests__/run-notebook-cell.test.ts
@@ -25,23 +25,19 @@ const mockNotebook = {
 
 describe("runNotebookCell", () => {
 	beforeEach(() => {
-		;(vscode.Uri.file as vi.MockedFunction<typeof vscode.Uri.file>).mockImplementation((p: string) => ({
+		;(vscode.Uri.file as any).mockImplementation((p: string) => ({
 			fsPath: p,
 			path: p,
 		}))
-		;(
-			vscode.workspace.openTextDocument as vi.MockedFunction<typeof vscode.workspace.openTextDocument>
-		).mockResolvedValue({
+		;(vscode.workspace.openTextDocument as any).mockResolvedValue({
 			getText: () => JSON.stringify(mockNotebook),
 		} as any)
-		;(
-			vscode.NotebookCellOutputItem.text as vi.MockedFunction<typeof vscode.NotebookCellOutputItem.text>
-		).mockImplementation((value: string, mime: string) => ({
+		;(vscode.NotebookCellOutputItem.text as any).mockImplementation((value: string, mime: string) => ({
 			data: Buffer.from(value),
 			mime,
 		}))
-		;(fs.writeFile as vi.MockedFunction<typeof fs.writeFile>).mockResolvedValue(undefined)
-		;(fs.unlink as vi.MockedFunction<typeof fs.unlink>).mockResolvedValue(undefined)
+		;(fs.writeFile as any).mockResolvedValue(undefined)
+		;(fs.unlink as any).mockResolvedValue(undefined)
 	})
 
 	afterEach(() => {

--- a/src/services/mem0/__tests__/mem0_client.spec.ts
+++ b/src/services/mem0/__tests__/mem0_client.spec.ts
@@ -1,29 +1,29 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, type Mock } from "vitest"
 import axios from "axios"
 import { configureMem0, search_memories, store_memory } from "../mem0_client"
 
 vi.mock("axios")
-const mockedAxios = axios as unknown as { post: vi.Mock }
+const mockedAxios = axios as unknown as { post: Mock }
 
 mockedAxios.post = vi.fn()
 
 describe("mem0 client", () => {
-    it("search_memories skips when disabled", async () => {
-        configureMem0({ enabled: false })
-        const res = await search_memories("q", "u", "a")
-        expect(res).toBeNull()
-        expect(mockedAxios.post).not.toHaveBeenCalled()
-    })
+	it("search_memories skips when disabled", async () => {
+		configureMem0({ enabled: false })
+		const res = await search_memories("q", "u", "a")
+		expect(res).toBeNull()
+		expect(mockedAxios.post).not.toHaveBeenCalled()
+	})
 
-    it("store_memory sends request when enabled", async () => {
-        configureMem0({ enabled: true, baseUrl: "http://x" })
-        mockedAxios.post.mockResolvedValue({ data: [] })
-        await store_memory([], "u", "a")
-        expect(mockedAxios.post).toHaveBeenCalledWith("http://x/memories", {
-            messages: [],
-            user_id: "u",
-            agent_id: "a",
-            metadata: undefined,
-        })
-    })
+	it("store_memory sends request when enabled", async () => {
+		configureMem0({ enabled: true, baseUrl: "http://x" })
+		mockedAxios.post.mockResolvedValue({ data: [] })
+		await store_memory([], "u", "a")
+		expect(mockedAxios.post).toHaveBeenCalledWith("http://x/memories", {
+			messages: [],
+			user_id: "u",
+			agent_id: "a",
+			metadata: undefined,
+		})
+	})
 })

--- a/src/services/reference-index/interfaces/config.ts
+++ b/src/services/reference-index/interfaces/config.ts
@@ -17,6 +17,7 @@ export interface ReferenceIndexConfig {
 	qdrantApiKey?: string
 	searchMinScore?: number
 	searchMaxResults?: number
+	rootPath?: string
 }
 
 /**
@@ -35,4 +36,5 @@ export type PreviousConfigSnapshot = {
 	geminiApiKey?: string
 	qdrantUrl?: string
 	qdrantApiKey?: string
+	rootPath?: string
 }

--- a/src/services/reference-index/processors/scanner.ts
+++ b/src/services/reference-index/processors/scanner.ts
@@ -169,6 +169,7 @@ export class DirectoryScanner implements IDirectoryScanner {
 												batchBlocks,
 												batchTexts,
 												batchFileInfos,
+												directoryPath,
 												onError,
 												onBlocksIndexed,
 											),
@@ -214,7 +215,7 @@ export class DirectoryScanner implements IDirectoryScanner {
 
 				// Queue final batch processing
 				const batchPromise = batchLimiter(() =>
-					this.processBatch(batchBlocks, batchTexts, batchFileInfos, onError, onBlocksIndexed),
+					this.processBatch(batchBlocks, batchTexts, batchFileInfos, directoryPath, onError, onBlocksIndexed),
 				)
 				activeBatchPromises.push(batchPromise)
 			} finally {
@@ -267,6 +268,7 @@ export class DirectoryScanner implements IDirectoryScanner {
 		batchBlocks: CodeBlock[],
 		batchTexts: string[],
 		batchFileInfos: { filePath: string; fileHash: string; isNew: boolean }[],
+		directory: string,
 		onError?: (error: Error) => void,
 		onBlocksIndexed?: (indexedCount: number) => void,
 	): Promise<void> {


### PR DESCRIPTION
## Summary
- update global settings schema
- include mem0 `machineId`
- add missing import for `store_memory`
- update test mocks for `vitest`
- add rootPath property to reference index config
- propagate directory path in scanner

## Testing
- `npx tsc -p src/tsconfig.json --noEmit` *(fails: Property 'machineId' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6869c57fabf0832f9a5bac79a3a9886d