### PR TITLE
Fix missing machineId and rootPath types

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1727,6 +1727,7 @@ export class ClineProvider
 				codebaseIndexEmbedderModelId: "",
 			},
 			profileThresholds: stateValues.profileThresholds ?? {},
+			machineId: vscode.env.machineId,
 		}
 	}
 

--- a/src/services/reference-index/config-manager.ts
+++ b/src/services/reference-index/config-manager.ts
@@ -127,6 +127,7 @@ export class ReferenceIndexConfigManager {
 			qdrantUrl?: string
 			qdrantApiKey?: string
 			searchMinScore?: number
+			rootPath?: string
 		}
 		requiresRestart: boolean
 	}> {


### PR DESCRIPTION
## Summary
- expose `machineId` from `getState`
- include `rootPath` field in Reference Index config type

## Testing
- `pnpm --filter ./src run check-types`
- `pnpm --filter "./packages/types" run check-types`


------
https://chatgpt.com/codex/tasks/task_e_6869c8ab47bc832fb7252258b0839c0d