### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -39,7 +39,7 @@ import { getApiMetrics } from "../../shared/getApiMetrics"
 import { ClineAskResponse } from "../../shared/WebviewMessage"
 import { defaultModeSlug } from "../../shared/modes"
 import { DiffStrategy } from "../../shared/tools"
-import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
+import { EXPERIMENT_IDS, experiments as experimentUtils } from "../../shared/experiments"
 
 // services
 import { UrlContentFetcher } from "../../services/browser/UrlContentFetcher"
@@ -265,7 +265,7 @@ export class Task extends EventEmitter<ClineEvents> {
 		this.diffViewProvider = new DiffViewProvider(this.cwd)
 		this.enableCheckpoints = enableCheckpoints
 		this.experiments = experiments
-		this.conversationSaver = new ConversationSaver(this.experiments)
+		this.conversationSaver = new ConversationSaver(this.experiments, provider.contextProxy)
 
 		this.rootTask = rootTask
 		this.parentTask = parentTask
@@ -285,7 +285,7 @@ export class Task extends EventEmitter<ClineEvents> {
 
 			// Check experiment asynchronously and update strategy if needed
 			provider.getState().then((state) => {
-				const isMultiFileApplyDiffEnabled = experiments.isEnabled(
+				const isMultiFileApplyDiffEnabled = experimentUtils.isEnabled(
 					state.experiments ?? {},
 					EXPERIMENT_IDS.MULTI_FILE_APPLY_DIFF,
 				)

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -249,6 +249,22 @@ export interface WebviewMessage {
 		codeIndexQdrantApiKey?: string
 		codebaseIndexOpenAiCompatibleApiKey?: string
 		codebaseIndexGeminiApiKey?: string
+
+		// Reference index global state settings
+		referenceIndexEnabled?: boolean
+		referenceIndexRootPath?: string
+		referenceIndexQdrantUrl?: string
+		referenceIndexEmbedderProvider?: "openai" | "ollama" | "openai-compatible" | "gemini"
+		referenceIndexEmbedderBaseUrl?: string
+		referenceIndexEmbedderModelId?: string
+		referenceIndexOpenAiCompatibleBaseUrl?: string
+		referenceIndexOpenAiCompatibleModelDimension?: number
+		referenceIndexSearchMaxResults?: number
+		referenceIndexSearchMinScore?: number
+
+		// Reference index secret settings
+		referenceIndexOpenAiCompatibleApiKey?: string
+		referenceIndexGeminiApiKey?: string
 	}
 }
 


### PR DESCRIPTION
## Summary
- pass provider context to ConversationSaver
- avoid variable shadowing for experiments check
- add reference index settings to Webview message payload

## Testing
- `npx tsc --noEmit -p src/tsconfig.json`
- `npx tsc --noEmit -p webview-ui/tsconfig.json`
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm check-types` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm test` *(fails: connect ENETUNREACH 104.16.0.35:443)*

------
https://chatgpt.com/codex/tasks/task_e_6869d7a99948832fb4369766628f9e3c