### PR TITLE
Fix conversation path position in experimental panel

### DIFF
--- a/webview-ui/src/components/settings/ExperimentalSettings.tsx
+++ b/webview-ui/src/components/settings/ExperimentalSettings.tsx
@@ -75,12 +75,26 @@ export const ExperimentalSettings = ({
 					.map(([key]) => {
 						const experimentId = EXPERIMENT_IDS[key as keyof typeof EXPERIMENT_IDS]
 						return (
-							<ExperimentalFeature
-								key={key}
-								experimentKey={key}
-								enabled={experiments[experimentId] ?? false}
-								onChange={(enabled) => setExperimentEnabled(experimentId, enabled)}
-							/>
+							<div key={key}>
+								<ExperimentalFeature
+									experimentKey={key}
+									enabled={experiments[experimentId] ?? false}
+									onChange={(enabled) => setExperimentEnabled(experimentId, enabled)}
+								/>
+								{experimentId === EXPERIMENT_IDS.LLM_CONVERSATION_SAVING &&
+									experiments.llmConversationSaving && (
+										<VSCodeTextField
+											value={llmConversationStoragePath ?? ""}
+											onChange={(e: any) =>
+												setCachedStateField &&
+												setCachedStateField("llmConversationStoragePath", e.target.value)
+											}
+											placeholder=".roo/conversations"
+											className="w-full ml-6 mt-2"
+											aria-label="Conversation Storage Path"
+										/>
+									)}
+							</div>
 						)
 					})}
 
@@ -187,21 +201,6 @@ export const ExperimentalSettings = ({
 						/>
 					)}
 				</div>
-
-				{/* Conversation Saving Path */}
-				{experiments.llmConversationSaving && (
-					<div className="mt-4 ml-6">
-						<VSCodeTextField
-							value={llmConversationStoragePath ?? ""}
-							onChange={(e: any) =>
-								setCachedStateField && setCachedStateField("llmConversationStoragePath", e.target.value)
-							}
-							placeholder=".roo/conversations"
-							className="w-full"
-							aria-label="Conversation Storage Path"
-						/>
-					</div>
-				)}
 			</Section>
 		</div>
 	)


### PR DESCRIPTION
## Summary
- tweak `ExperimentalSettings` so conversation storage path field renders below the toggle

## Testing
- `pnpm --filter @roo-code/vscode-webview lint`
- `pnpm --filter @roo-code/vscode-webview format`
- `pnpm --filter @roo-code/vscode-webview test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6869dfbbd3b8832f871e68fccfb23dc2