### PR TITLE
Fix reference index toggle

### DIFF
--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1142,6 +1142,21 @@ export const webviewMessageHandler = async (
 
 			await provider.postStateToWebview()
 			break
+		case "referenceIndexEnabled":
+			// Update the referenceIndexConfig with the new enabled state
+			const currentReferenceConfig = getGlobalState("referenceIndexConfig") || {}
+			await updateGlobalState("referenceIndexConfig", {
+				...currentReferenceConfig,
+				referenceIndexEnabled: message.bool ?? false,
+			})
+
+			// Notify the reference index manager about the change
+			if (provider.referenceIndexManager) {
+				await provider.referenceIndexManager.handleSettingsChange()
+			}
+
+			await provider.postStateToWebview()
+			break
 		case "language":
 			changeLanguage(message.text ?? "en")
 			await updateGlobalState("language", message.text as Language)

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -144,6 +144,7 @@ export interface WebviewMessage {
 		| "humanRelayCancel"
 		| "browserToolEnabled"
 		| "codebaseIndexEnabled"
+		| "referenceIndexEnabled"
 		| "telemetrySetting"
 		| "showRooIgnoredFiles"
 		| "testBrowserConnection"

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -331,6 +331,9 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 			if (codebaseIndexConfig) {
 				vscode.postMessage({ type: "codebaseIndexEnabled", bool: codebaseIndexConfig.codebaseIndexEnabled })
 			}
+			if (referenceIndexConfig) {
+				vscode.postMessage({ type: "referenceIndexEnabled", bool: referenceIndexConfig.referenceIndexEnabled })
+			}
 			vscode.postMessage({ type: "profileThresholds", values: profileThresholds })
 			setChangeDetected(false)
 		}


### PR DESCRIPTION
## Summary
- ensure reference index checkbox updates its own config
- propagate the setting to the extension

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm test` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6869e52ff8d4832f9594f6346826d0d0