### PR TITLE
Fix undefined referenceIndex variables

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1449,6 +1449,8 @@ export class ClineProvider
 			customCondensingPrompt,
 			codebaseIndexConfig,
 			codebaseIndexModels,
+			referenceIndexConfig,
+			referenceIndexModels,
 			profileThresholds,
 			alwaysAllowFollowupQuestions,
 			followupAutoApproveTimeoutMs,


### PR DESCRIPTION
## Summary
- ensure `referenceIndexConfig` and `referenceIndexModels` are pulled from the state in `ClineProvider`

## Testing
- `npx tsc -p src/tsconfig.json --noEmit`
- `pnpm run check-types` *(fails: ENETUNREACH to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6869efe1a474832f8ed208557e295379