### PR TITLE
Add Mem0 API key support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,4 @@ CLERK_BASE_URL=https://epic-chamois-85.clerk.accounts.dev
 ROO_CODE_API_URL=http://localhost:3000
 MEM0_ENABLED=false
 MEM0_API_SERVER_URL=http://localhost:4321
+MEM0_API_KEY=

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1593,11 +1593,12 @@ export class ClineProvider
 
 		const mem0EnabledEnv = process.env.MEM0_ENABLED === "true"
 		const mem0UrlEnv = process.env.MEM0_API_SERVER_URL
+		const mem0ApiKeyEnv = process.env.MEM0_API_KEY
 
 		const mem0Enabled = stateValues.mem0Enabled ?? mem0EnabledEnv
 		const mem0ApiServerUrl = stateValues.mem0ApiServerUrl ?? mem0UrlEnv
 
-		configureMem0({ enabled: mem0Enabled ?? false, baseUrl: mem0ApiServerUrl })
+		configureMem0({ enabled: mem0Enabled ?? false, baseUrl: mem0ApiServerUrl, apiKey: mem0ApiKeyEnv })
 		const customModes = await this.customModesManager.getCustomModes()
 
 		// Determine apiProvider with the same logic as before.

--- a/src/services/mem0/__tests__/mem0_client.spec.ts
+++ b/src/services/mem0/__tests__/mem0_client.spec.ts
@@ -19,11 +19,31 @@ describe("mem0 client", () => {
 		configureMem0({ enabled: true, baseUrl: "http://x" })
 		mockedAxios.post.mockResolvedValue({ data: [] })
 		await store_memory([], "u", "a")
-		expect(mockedAxios.post).toHaveBeenCalledWith("http://x/memories", {
-			messages: [],
-			user_id: "u",
-			agent_id: "a",
-			metadata: undefined,
-		})
+		expect(mockedAxios.post).toHaveBeenCalledWith(
+			"http://x/memories",
+			{
+				messages: [],
+				user_id: "u",
+				agent_id: "a",
+				metadata: undefined,
+			},
+			{ headers: {} },
+		)
+	})
+
+	it("store_memory includes api key when provided", async () => {
+		configureMem0({ enabled: true, baseUrl: "http://x", apiKey: "key" })
+		mockedAxios.post.mockResolvedValue({ data: [] })
+		await store_memory([], "u", "a")
+		expect(mockedAxios.post).toHaveBeenCalledWith(
+			"http://x/memories",
+			{
+				messages: [],
+				user_id: "u",
+				agent_id: "a",
+				metadata: undefined,
+			},
+			{ headers: { "api-key": "key", Authorization: "Bearer key" } },
+		)
 	})
 })

--- a/src/services/mem0/mem0_client.ts
+++ b/src/services/mem0/mem0_client.ts
@@ -2,46 +2,60 @@ import axios from "axios"
 
 let cachedBaseUrl: string | undefined
 let cachedEnabled: boolean | undefined
+let cachedApiKey: string | undefined
 
-export function configureMem0(options: { enabled: boolean; baseUrl?: string }) {
-    cachedEnabled = options.enabled
-    cachedBaseUrl = options.baseUrl
+export function configureMem0(options: { enabled: boolean; baseUrl?: string; apiKey?: string }) {
+	cachedEnabled = options.enabled
+	cachedBaseUrl = options.baseUrl
+	cachedApiKey = options.apiKey
 }
 
 function getBaseUrl() {
-    return cachedBaseUrl?.replace(/\/$/, "")
+	return cachedBaseUrl?.replace(/\/$/, "")
+}
+
+function getHeaders() {
+	const headers: Record<string, string> = {}
+	if (cachedApiKey) {
+		headers["api-key"] = cachedApiKey
+		headers["Authorization"] = `Bearer ${cachedApiKey}`
+	}
+	return headers
 }
 
 export async function search_memories(query: string, user_id: string, agent_id: string) {
-    if (!cachedEnabled || !cachedBaseUrl) return null
-    try {
-        const { data } = await axios.post(`${getBaseUrl()}/search`, {
-            query,
-            user_id,
-            agent_id,
-        })
-        return data
-    } catch (error) {
-        console.error("[Mem0] search_memories error", error)
-        return null
-    }
+	if (!cachedEnabled || !cachedBaseUrl) return null
+	try {
+		const { data } = await axios.post(
+			`${getBaseUrl()}/search`,
+			{
+				query,
+				user_id,
+				agent_id,
+			},
+			{ headers: getHeaders() },
+		)
+		return data
+	} catch (error) {
+		console.error("[Mem0] search_memories error", error)
+		return null
+	}
 }
 
-export async function store_memory(
-    messages: any[],
-    user_id: string,
-    agent_id: string,
-    metadata?: Record<string, any>,
-) {
-    if (!cachedEnabled || !cachedBaseUrl) return
-    try {
-        await axios.post(`${getBaseUrl()}/memories`, {
-            messages,
-            user_id,
-            agent_id,
-            metadata,
-        })
-    } catch (error) {
-        console.error("[Mem0] store_memory error", error)
-    }
+export async function store_memory(messages: any[], user_id: string, agent_id: string, metadata?: Record<string, any>) {
+	if (!cachedEnabled || !cachedBaseUrl) return
+	try {
+		await axios.post(
+			`${getBaseUrl()}/memories`,
+			{
+				messages,
+				user_id,
+				agent_id,
+				metadata,
+			},
+			{ headers: getHeaders() },
+		)
+	} catch (error) {
+		console.error("[Mem0] store_memory error", error)
+	}
 }


### PR DESCRIPTION
## Summary
- support Mem0 API key and headers
- wire up MEM0_API_KEY env var
- document API key in `.env.sample`
- test Mem0 client with/without API key

## Testing
- `npx vitest run src/services/mem0/__tests__/mem0_client.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_6869fc6a2438832f88baf82c7df281ec