### PR TITLE
Fix start indexing message handler

### DIFF
--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -2054,13 +2054,26 @@ export const webviewMessageHandler = async (
 		}
 		case "startIndexing": {
 			try {
-				const manager = provider.codeIndexManager!
-				if (manager.isFeatureEnabled && manager.isFeatureConfigured) {
-					if (!manager.isInitialized) {
-						await manager.initialize(provider.contextProxy)
-					}
+				const managers = [provider.codeIndexManager, provider.referenceIndexManager].filter(
+					(
+						m,
+					): m is {
+						isFeatureEnabled: boolean
+						isFeatureConfigured: boolean
+						isInitialized: boolean
+						initialize: (contextProxy: ContextProxy) => Promise<any>
+						startIndexing: () => void
+					} => m !== undefined,
+				)
 
-					manager.startIndexing()
+				for (const manager of managers) {
+					if (manager.isFeatureEnabled && manager.isFeatureConfigured) {
+						if (!manager.isInitialized) {
+							await manager.initialize(provider.contextProxy)
+						}
+
+						manager.startIndexing()
+					}
 				}
 			} catch (error) {
 				provider.log(`Error starting indexing: ${error instanceof Error ? error.message : String(error)}`)


### PR DESCRIPTION
## Summary
- handle startIndexing message for reference index manager too

## Testing
- `pnpm lint` *(fails: Error when performing request to registry.npmjs.org)*
- `pnpm test` *(fails: connect ENETUNREACH 104.16.27.34:443)*

------
https://chatgpt.com/codex/tasks/task_e_686a48734a28832f906fd14b93d240e5