### PR TITLE
Fix some ESLint warnings

### DIFF
--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -39,11 +39,11 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 	async *createMessage(
 		systemPrompt: string,
 		messages: Anthropic.Messages.MessageParam[],
-		metadata?: ApiHandlerCreateMessageMetadata,
+		_metadata?: ApiHandlerCreateMessageMetadata,
 	): ApiStream {
 		let stream: AnthropicStream<Anthropic.Messages.RawMessageStreamEvent>
 		const cacheControl: CacheControlEphemeral = { type: "ephemeral" }
-		let { id: modelId, betas = [], maxTokens, temperature, reasoning: thinking } = this.getModel()
+		const { id: modelId, betas = [], maxTokens, temperature, reasoning: thinking } = this.getModel()
 
 		switch (modelId) {
 			case "claude-sonnet-4-20250514":
@@ -128,7 +128,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 					system: [{ text: systemPrompt, type: "text" }],
 					messages,
 					stream: true,
-				})) as any
+				})) as unknown as AnthropicStream<Anthropic.Messages.RawMessageStreamEvent>
 				break
 			}
 		}
@@ -233,7 +233,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 
 	getModel() {
 		const modelId = this.options.apiModelId
-		let id = modelId && modelId in anthropicModels ? (modelId as AnthropicModelId) : anthropicDefaultModelId
+		const id = modelId && modelId in anthropicModels ? (modelId as AnthropicModelId) : anthropicDefaultModelId
 		const info: ModelInfo = anthropicModels[id]
 
 		const params = getModelParams({
@@ -256,7 +256,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 	}
 
 	async completePrompt(prompt: string) {
-		let { id: model, temperature } = this.getModel()
+		const { id: model, temperature } = this.getModel()
 
 		const message = await this.client.messages.create({
 			model,


### PR DESCRIPTION
## Summary
- address some `prefer-const` and unused variable warnings in `anthropic.ts`

## Testing
- `npx eslint api/providers/anthropic.ts --max-warnings=0`
- `pnpm run lint` *(fails: ESLint found too many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686c461bc630832fac1fc5de0c7747b7